### PR TITLE
Fix null parentWikiId error

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: knit2synapse
 Type: Package
 Title: Knit RMarkdown to a Synapse Wiki page.
 Version: 2.0.2
-Date: 2015-04-27
+Date: 2024-12-02
 Authors@R: c(
     person("Brian", "Bot", email = "some@email.com", role = "cre"),
     person("Kenneth", "Daily", email = "kenneth.daily@sagebase.org", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: knit2synapse
 Type: Package
 Title: Knit RMarkdown to a Synapse Wiki page.
-Version: 2.0.1
+Version: 2.0.2
 Date: 2015-04-27
 Authors@R: c(
     person("Brian", "Bot", email = "some@email.com", role = "cre"),

--- a/R/knitfile2synapse.R
+++ b/R/knitfile2synapse.R
@@ -100,7 +100,7 @@ knitfile2synapse <- function(file, owner, parentWikiId=NULL, wikiName=NULL, over
   if (class(w)[1] == 'try-error') {
     w <- newWiki
     # delete existing wiki along with history
-  } else if (overwrite && is.na(parentWikiId)) {
+  } else if (overwrite && is.null(parentWikiId)) {
     w <- synapser::synDelete(w)
     w <- newWiki
     # update existing wiki

--- a/R/knitfile2synapse.R
+++ b/R/knitfile2synapse.R
@@ -69,6 +69,11 @@ knitfile2synapse <- function(file, owner, parentWikiId=NULL, wikiName=NULL, over
   att <- as.list(list.files(knitPlotDir, full.names=TRUE))
   
   # New wiki page
+
+  # Fix to avoid casting NULL parentWikiId to a string
+  if (!is.null(parentWikiId)) {
+    parentWikiId = as.character(parentWikiId)
+  }
   
   # A quick fix for SYNR-1270/SYNPY-689
   # https://sagebionetworks.jira.com/browse/SYNPY-689
@@ -78,14 +83,14 @@ knitfile2synapse <- function(file, owner, parentWikiId=NULL, wikiName=NULL, over
     newWiki <- synapser::Wiki(owner=owner,
                               title=wikiName,
                               markdownFile=mdFile,
-                              parentWikiId=as.character(parentWikiId))
+                              parentWikiId=parentWikiId)
   }
   else {
     newWiki <- synapser::Wiki(owner=owner,
                               title=wikiName,
                               markdownFile=mdFile,
                               attachments=att,
-                              parentWikiId=as.character(parentWikiId))
+                              parentWikiId=parentWikiId)
   }
 
   ## Create/retrieve and store Wiki markdown to Synapse

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 First, install the `synapser` package:
 
 ```
-install.packages("synapser", repos=c("https://sage-bionetworks.github.io/staging-ran", "http://cran.fhcrc.org"))
+install.packages("synapser", repos = c("http://ran.synapse.org", "https://cloud.r-project.org"))
 ```
 
 The, using `devtools`:
@@ -21,7 +21,7 @@ devtools::install_github("Sage-Bionetworks/knit2synapse")
 `knitfile2synapse(markdownfile, owner='syn123', parentWikiId = NULL, wikiName = NULL, overwrite = FALSE)`
 
 * `markdownfile`: a path to a markdown file (including RMarkdown files)
-* `owner`: The Entity where the Wiki page should go (this can be a `Project`, `File`, or `Folder` entity)
+* `owner`: The Entity where the Wiki page should go (this can be a synapser `Project`, `File`, or `Folder` object, or a string specifying the Synapse ID)
 * `parentWikiId`: If supplied, will make a sub-Wiki underneath this Wiki ID. Note that this is not a Synapse ID (does not start with `syn`, it is an integer)
 
 


### PR DESCRIPTION
This PR fixes [this issue](https://github.com/Sage-Bionetworks/knit2synapse/issues/9) (I think, I can't see the thread linked in the issue), where if you do not specify `parentWikiId` or pass `parentWikiId = NULL` as an argument to `knitfile2synapse`, it gets cast to a string and the synapse client can't interpret this correctly, which throws an error. 